### PR TITLE
1.11.1-99: Update to 1.11.1 and simplify get_sources script

### DIFF
--- a/SPECS/seabios.spec
+++ b/SPECS/seabios.spec
@@ -1,17 +1,12 @@
 Name:           seabios
-Version:        1.10.0
-Release:        1%{?dist}
+Version:        1.11.1
+Release:        99%{?dist}
 Summary:        Open-source legacy BIOS implementation
 
 Group:          Applications/Emulators
 License:        LGPLv3
 URL:            http://www.coreboot.org/SeaBIOS
-# No source releases of seabios stable. To generate:
-# git clone git://git.seabios.org/seabios.git && cd seabios
-# R=%{version}; git archive --output seabios-$R.tar.gz --prefix seabios-$R/ rel-$R
-#
-# Or use get_sources.sh
-Source0:        http://code.coreboot.org/p/seabios/downloads/get/%{name}-%{version}.tar.gz
+Source0:        https://review.coreboot.org/cgit/seabios.git/snapshot/%{name}-rel-%{version}.tar.gz
 
 BuildRequires: python iasl
 ExclusiveArch: x86_64
@@ -51,7 +46,7 @@ that a typical x86 proprietary BIOS implements.
 
 
 %prep
-%setup -q
+%setup -q -n %{name}-rel-%{version}
 
 # Makefile changes version to include date and buildhost
 sed -i 's,VERSION=%{version}.*,VERSION=%{version},g' Makefile
@@ -86,6 +81,12 @@ install -m 0644 out/bios.bin $RPM_BUILD_ROOT%{_datadir}/seabios
 
 
 %changelog
+* Wed May 09 2018 Kevin Stange <kevin@steadfast.net> - 1.11.1-99
+- Update to 1.11.1
+
+* Mon Sep 11 2017 Johnny Hughes <johnny@centos.org> - 1.10.2-99
+- Update to 1.10.2
+
 * Thu Apr 27 2017 George Dunlap <george.dunlap@citrix.com> - 1.10.0-1
 - Update to 1.10.0
 

--- a/get_sources.sh
+++ b/get_sources.sh
@@ -1,25 +1,13 @@
 #!/bin/bash
-SEABIOS_VERSION=1.10.0
-SEABIOS_URL=git://git.seabios.org/seabios.git
-SEABIOS_FILE=seabios-$SEABIOS_VERSION.tar.gz
-SEABIOS_REF=rel-$SEABIOS_VERSION
+SEABIOS_VERSION=`grep ^Version: SPECS/seabios.spec | cut -d: -f2 | tr -d '[:space:]'` 
+SEABIOS_URL=https://review.coreboot.org/cgit/seabios.git/snapshot/
+SEABIOS_FILE=seabios-rel-$SEABIOS_VERSION.tar.gz
 
 echo "Checking Seabios $SEABIOS_VERSION release tarball"
 if [[ ! -e SOURCES/$SEABIOS_FILE ]] ; then
-    mkdir -p git-tmp
-    pushd git-tmp
-    
-    echo " Cloning seabios repo..."
-    git clone $SEABIOS_URL seabios.git || exit 1
-    cd seabios.git
-    echo " Creating $SEABIOS_FILE..."
-    git archive --prefix=seabios-$SEABIOS_VERSION/ -o ../../SOURCES/$SEABIOS_FILE $SEABIOS_REF || exit 1
-    popd
-fi
-
-if [[ -e git-tmp ]] ; then
-    echo "Cleaning up cloned repositores"
-    rm -rf git-tmp
+    mkdir -p SOURCES/
+    cd SOURCES/
+    wget $SEABIOS_URL/$SEABIOS_FILE
 fi
 
 echo "All sources present."


### PR DESCRIPTION
I updated seabios to 1.11.1 because Red Hat's seabios 1.11.0 is still broken for Xen HVM guests.  Tested 1.11.1 on Xen 4.8 and guests boot fine.

I also removed the git checkout stuff from get_sources.sh because there are source tarballs available from the site again.